### PR TITLE
Fix package.json - remove npm bin prefix for OS compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
     "webpack": "1.12.2"
   },
   "scripts": {
-    "webpack": "$(npm bin)/webpack -w"
+    "webpack": "webpack -w"
   }
 }


### PR DESCRIPTION
npm bin directory is automatically included in path when evaluating package.json scripts